### PR TITLE
fix(rag): support multiple inline citations in chat messages

### DIFF
--- a/client/src/components/ChatArea.tsx
+++ b/client/src/components/ChatArea.tsx
@@ -93,7 +93,7 @@ function linkifyText(text: string): string {
   return protectedText;
 }
 
-const CITATION_REGEX = /\[(\d{1,3})\]/g;
+const CITATION_REGEX = /\[(\d{1,3}(?:\s*,\s*\d{1,3})*)\]/g;
 
 const CitationBadge = ({
   children,
@@ -152,14 +152,33 @@ const renderTextWithCitations = (
     if (matchIndex > lastIndex) {
       nodes.push(text.slice(lastIndex, matchIndex));
     }
-    const citationNumber = Number(match[1]);
+    const citationNumbers = match[1]
+      .split(",")
+      .map((value) => value.trim())
+      .filter(Boolean)
+      .map((value) => Number(value))
+      .filter((value) => Number.isFinite(value));
     nodes.push(
-      <CitationBadge
+      <Box
         key={`${matchIndex}-${match[1]}`}
-        onClick={() => onCitationClick(citationNumber)}
+        component="span"
+        sx={{
+          display: "inline-flex",
+          alignItems: "center",
+          gap: "0.2em",
+          marginLeft: "0.05em",
+          marginRight: "0.05em",
+        }}
       >
-        {match[1]}
-      </CitationBadge>,
+        {citationNumbers.map((citationNumber) => (
+          <CitationBadge
+            key={`${matchIndex}-${citationNumber}`}
+            onClick={() => onCitationClick(citationNumber)}
+          >
+            {citationNumber}
+          </CitationBadge>
+        ))}
+      </Box>,
     );
     lastIndex = matchIndex + match[0].length;
   }


### PR DESCRIPTION
This pull request improves how citation references are detected and rendered in chat messages, allowing for multiple citations within a single set of brackets (e.g., `[1, 2, 3]`). The changes update both the regular expression for citation matching and the rendering logic to support multiple citation badges grouped together.

**Citation handling improvements:**

* Updated the `CITATION_REGEX` in `ChatArea.tsx` to match one or more comma-separated citation numbers within brackets, enabling detection of multiple citations like `[1, 2, 3]`.
* Modified the `renderTextWithCitations` function to parse, split, and render each citation number in a group as a separate `CitationBadge` inside a styled container, ensuring each badge is clickable and visually grouped.