### PR TITLE
Enhance hybrid retrieval with static resume fallback

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -61,7 +61,7 @@ Lumina is a full-stack AI-powered chatbot application that leverages Retrieval-A
 2. **Stateless API Design**: RESTful APIs with JWT-based authentication
 3. **Scalable Data Layer**: Distributed databases (MongoDB + Pinecone + Neo4j)
 4. **Hybrid Retrieval**: Parallel vector similarity and graph traversal with merged scoring
-5. **Graceful Degradation**: System operates in vector-only mode when graph DB is unavailable
+5. **Graceful Degradation**: System operates in vector-only mode when graph DB is unavailable and can use static resume fallback context when live retrieval backends fail
 6. **Event-Driven Communication**: Real-time updates and async processing
 7. **Security First**: JWT authentication, encrypted passwords, CORS protection
 
@@ -605,7 +605,7 @@ sequenceDiagram
 
 ### RAG Implementation
 
-The RAG (Retrieval-Augmented Generation) system grounds responses in knowledge retrieved from both Pinecone (vector similarity) and Neo4j (graph traversal), always returning inline citations with a sources list. Knowledge is ingested through CLI tools (REPL or one-off commands) and stored in MongoDB + Pinecone + Neo4j for retrieval. At query time, both retrieval paths run in parallel via `Promise.allSettled`, and results are merged, deduplicated, and scored before being passed to the generation phase.
+The RAG (Retrieval-Augmented Generation) system grounds responses in knowledge retrieved from both Pinecone (vector similarity) and Neo4j (graph traversal), always returning inline citations with a sources list. Knowledge is ingested through CLI tools (REPL or one-off commands) and stored in MongoDB + Pinecone + Neo4j for retrieval. At query time, both retrieval paths run in parallel via `Promise.allSettled`, and results are merged, deduplicated, and scored before being passed to the generation phase. If live retrieval backends fail, the system can load static resume fallback context from local knowledge manifest/files.
 
 ```mermaid
 graph TB
@@ -658,7 +658,7 @@ graph TB
 
 ### Hybrid Retrieval Pipeline
 
-The hybrid retrieval pipeline runs vector similarity search and graph traversal in parallel, then merges the results using a scoring algorithm that rewards chunks found by both paths.
+The hybrid retrieval pipeline runs vector similarity search and graph traversal in parallel, then merges the results using a scoring algorithm that rewards chunks found by both paths. A failure in one path does not block the other, and when live backend retrieval fails entirely, static resume fallback context is used.
 
 ```mermaid
 flowchart TD
@@ -1177,6 +1177,8 @@ flowchart TD
     style Merge fill:#9C27B0
 ```
 
+If both live retrieval paths fail due backend errors, fallback sources are loaded from `server/knowledge/manifest.json` and the referenced local files. This keeps responses grounded without introducing a UI-based knowledge mutation flow.
+
 ### Exhaustive List Retrieval
 
 For list-type queries (e.g., "list all projects", "show every skill", "what are all the awards"), the system detects list intent via regex and ensures complete coverage rather than returning only a top-K slice.
@@ -1535,7 +1537,7 @@ graph LR
 
 ## Graceful Degradation
 
-The system is designed to operate seamlessly even when individual components are unavailable. The Neo4j graph retrieval path is fully optional -- if the `NEO4J_URI` environment variable is not set, or if the Neo4j connection fails at runtime, the system automatically falls back to vector-only retrieval mode.
+The system is designed to operate seamlessly even when individual components are unavailable. The Neo4j graph retrieval path is fully optional -- if the `NEO4J_URI` environment variable is not set, or if the Neo4j connection fails at runtime, the system automatically falls back to vector-only retrieval mode. If live backend retrieval fails, a static resume fallback from local manifest/files is used before returning empty citations.
 
 ```mermaid
 flowchart TD
@@ -1553,7 +1555,10 @@ flowchart TD
     CheckResults -->|Yes| MergeBoth["Merge both result sets"]
     CheckResults -->|Vector only| UseVector["Use vector results only"]
     CheckResults -->|Graph only| UseGraph["Use graph results only"]
-    CheckResults -->|Both failed| EmptyResults["Return empty citations"]
+    CheckResults -->|Both failed| StaticFallback["Load static resume fallback<br/>(manifest + local files)"]
+    StaticFallback --> StaticAvailable{"Fallback sources found?"}
+    StaticAvailable -->|Yes| UseStatic["Use static fallback sources"]
+    StaticAvailable -->|No| EmptyResults["Return empty citations"]
 
     VectorOnly --> PineconeSearch["Standard Pinecone search"]
     FallbackVector --> PineconeSearch
@@ -1572,13 +1577,14 @@ flowchart TD
 | **Neo4j connection failure** | Graph path returns empty via `Promise.allSettled` | Slightly reduced retrieval diversity; no errors surfaced |
 | **Neo4j timeout** | Graph path settles as rejected | Vector results used; response time unaffected |
 | **Pinecone failure** | Vector path returns empty | Graph results used alone (reduced coverage) |
-| **Both fail** | Empty citation list | AI generates response without grounding context |
+| **Both live retrieval backends fail** | Load static resume fallback from local manifest/files; if unavailable, return empty citations | Responses are usually still grounded by fallback context |
 
 ### Key Design Decisions
 
 - **`Promise.allSettled` over `Promise.all`**: Ensures one failing path never blocks the other
 - **No hard dependency**: The `neo4jClient.ts` module initializes only when `NEO4J_URI` is present
 - **Connection health checks**: Neo4j driver verifies connectivity at startup; failures are logged but do not prevent server boot
+- **File-backed fallback context**: Static resume fallback reads `server/knowledge/manifest.json` and source files, so insert/update/delete remains easy through existing manifest/CLI workflows
 - **Rate-limit awareness**: Entity extraction uses exponential backoff to avoid Gemini API throttling
 - **Embedding retry with backoff**: Embedding generation retries up to 5 attempts with a 3-second backoff between each attempt on rate-limit (429) or transient errors, preventing ingestion failures during high-throughput upserts
 - **Batch entity extraction**: Chunks are grouped into batches of 5 per LLM call, reducing API request volume by up to 80% and improving ingestion throughput
@@ -2259,7 +2265,7 @@ This architecture document provides a comprehensive overview of the Lumina AI As
 
 - **Modular Design**: Clear separation between frontend, backend, and AI/ML components
 - **Hybrid Retrieval**: Parallel vector similarity (Pinecone) and graph traversal (Neo4j) with merged scoring for higher relevance
-- **Graceful Degradation**: Full backwards compatibility -- system operates in vector-only mode when Neo4j is unavailable
+- **Graceful Degradation**: Full backwards compatibility -- system operates in vector-only mode when Neo4j is unavailable and can use static resume fallback context when live retrieval backends fail
 - **Scalable Infrastructure**: Ready for horizontal scaling with cloud-native patterns
 - **Secure by Design**: Multiple layers of security from network to data
 - **Observable**: Comprehensive monitoring and logging capabilities

--- a/RAG.md
+++ b/RAG.md
@@ -1022,8 +1022,13 @@ flowchart TD
   VEC --> MERGE
 
   MERGE --> D{Sources found?}
-  D -- No --> FALL["Return: 'I don't have enough information...'<br/>sources: []"]
   D -- Yes --> E["Assemble grounded prompt"]
+  D -- No --> RET{Live retrieval backend failure?}
+  RET -- Yes --> SF["Load static resume fallback<br/>from local manifest + files"]
+  SF --> SFCHK{Fallback sources found?}
+  SFCHK -- Yes --> E
+  SFCHK -- No --> FALL["Return: 'I don't have enough information...'<br/>sources: []"]
+  RET -- No --> FALL
   E --> F["Call Gemini model"]
   F --> G{Model available?}
   G -- No --> H["Rotate to next model"]
@@ -1037,14 +1042,15 @@ flowchart TD
 | Embedding API 429 (rate limit)    | Exponential backoff retry (3s base, up to 5 attempts) before propagating error      |
 | Embedding API failure (non-429)   | Error propagated as 500 to client                                                   |
 | No matching sources               | Polite fallback message, empty sources array (not an error)                         |
-| Pinecone query failure            | Error propagated as 500 to client                                                   |
+| Pinecone query failure            | If graph path still succeeds, continue with graph-only sources; otherwise static resume fallback is attempted |
 | Vector deletion 404               | Silently ignored (already deleted)                                                  |
 | Primary Gemini model down         | Automatic rotation through fallback models                                          |
 | All Gemini models fail            | Last error thrown as 500 to client                                                  |
 | Model list API unavailable        | Falls back to static model list, then retries                                       |
 | Neo4j not configured              | System operates as pure vector RAG; graph features silently disabled                |
 | Neo4j connection failure at boot  | Warning logged; server continues without graph features                             |
-| Neo4j query failure at runtime    | Graph path returns empty results; vector results used alone (warning logged)        |
+| Neo4j query failure at runtime    | Graph failure does not block vector results; warning logged                          |
+| Both live retrieval backends fail | Static resume fallback is loaded from `server/knowledge/manifest.json` and local files |
 | Neo4j transient error             | Automatic retry with exponential backoff (500ms base, up to 3 attempts)             |
 | Graph ingestion failure           | Non-fatal; vector ingestion is preserved, warning logged                            |
 | Entity extraction rate limit (429)| Exponential backoff retry (15s, 30s, 45s) + model rotation through 6 Gemini models  |

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Alternatively, the backup app is deployed live on Netlify at: [https://lumina-ai
 - **Conversation History:** Save, retrieve, rename, and search past conversations (only for authenticated users).
 - **Auto-Generated Titles:** AI automatically generates concise, descriptive titles for new conversations based on the first message.
 - **Grounded Knowledge Base:** RAG (Retrieval-Augmented Generation) with Pinecone vector search and Neo4j graph traversal, plus inline citations; knowledge is managed via CLI (REPL or one-off commands) with manifest-based batch sync for easy knowledge management.
-- **Hybrid Graph + Vector RAG:** Parallel retrieval from Pinecone (semantic similarity) and Neo4j (entity-relationship traversal) with intelligent result merging, dual-source scoring, exhaustive list retrieval (automatically fetches ALL chunks from a dominant source for "list all" queries), batched entity extraction (5 chunks per LLM call for efficiency), and model rotation across 6 Gemini models for resilience.
+- **Hybrid Graph + Vector RAG:** Parallel retrieval from Pinecone (semantic similarity) and Neo4j (entity-relationship traversal) with intelligent result merging, dual-source scoring, exhaustive list retrieval (automatically fetches ALL chunks from a dominant source for "list all" queries), batched entity extraction (5 chunks per LLM call for efficiency), and model rotation across 6 Gemini models for resilience. Retrieval paths are isolated via `Promise.allSettled`, and a file-backed static resume fallback is used when live retrieval backends fail.
 - **Dynamic Responses:** AI-generated responses with `markdown` formatting for rich text.
 - **Interactive Chat:** Real-time chat interface with smooth animations and transitions.
 - **Reset Password:** Verify email and reset a user's password.
@@ -159,7 +159,7 @@ The project follows a modern, full-stack architecture with clear separation of c
   - **Augmentation**: Context building with conversation history
   - **Generation**: Response generation using Google Gemini AI
   - **Knowledge Storage**: CLI-driven ingestion into Pinecone with citations returned in responses
-  - **Graceful Degradation**: System operates as vector-only if Neo4j is unavailable
+  - **Graceful Degradation**: System operates as vector-only if Neo4j is unavailable, and can fall back to static resume context from local knowledge files when live retrieval backends fail
 
 For detailed architecture documentation, including component diagrams, data flows, and deployment strategies, see [ARCHITECTURE.md](ARCHITECTURE.md).
 
@@ -223,7 +223,7 @@ graph TB
 
 ### RAG (Retrieval-Augmented Generation) Flow
 
-Hybrid retrieval from Pinecone and Neo4j in parallel, followed by intelligent merging, augmentation with conversation history, and response generation with Google Gemini AI.
+Hybrid retrieval from Pinecone and Neo4j in parallel, followed by intelligent merging, augmentation with conversation history, and response generation with Google Gemini AI. One failing retrieval path never blocks the other, and if live retrieval backends fail, Lumina can fall back to static resume context loaded from local manifest/files.
 
 ```mermaid
 sequenceDiagram
@@ -444,7 +444,7 @@ For detailed instructions on managing knowledge (adding, updating, deleting), se
 
 ### Knowledge Management
 
-The knowledge base supports manifest-based batch sync, making it straightforward to add, update, or delete knowledge sources in bulk. The manifest file (`server/knowledge/manifest.json`) declaratively describes all knowledge files and their metadata, enabling one-command synchronization via `npm run knowledge:sync`. For the full guide covering single-file upserts, batch sync, graph rebuilds, and deletion workflows, see **[UPDATE_KNOWLEDGE.md](UPDATE_KNOWLEDGE.md)**.
+The knowledge base supports manifest-based batch sync, making it straightforward to add, update, or delete knowledge sources in bulk. The manifest file (`server/knowledge/manifest.json`) declaratively describes all knowledge files and their metadata, enabling one-command synchronization via `npm run knowledge:sync`. The same manifest/file set also powers the static resume fallback used during live retrieval backend failures, so fallback knowledge is easy to maintain without code changes. For the full guide covering single-file upserts, batch sync, graph rebuilds, and deletion workflows, see **[UPDATE_KNOWLEDGE.md](UPDATE_KNOWLEDGE.md)**.
 
 ## Deployment
 
@@ -1003,7 +1003,8 @@ AI-Assistant-Chatbot/
         │   ├── knowledgeBase.ts    # Chunking, embeddings, vector+graph retrieval
         │   ├── pineconeClient.ts   # Pinecone vector DB client
         │   ├── neo4jClient.ts      # Neo4j graph DB client
-        │   └── graphKnowledge.ts   # Graph entity extraction & retrieval
+        │   ├── graphKnowledge.ts   # Graph entity extraction & retrieval
+        │   └── staticResumeFallback.ts # File-backed fallback retrieval context
         ├── types/
         │   └── graph.ts            # Graph entity & relationship types
         ├── scripts/

--- a/server/README.md
+++ b/server/README.md
@@ -1,6 +1,6 @@
 # Lumina Backend (Server) 🚀
 
-This directory contains the **server** side of the **Lumina** project – a robust backend built with **Node.js** and **Express** using **TypeScript**. The backend provides all the necessary API endpoints for user authentication, conversation management, and AI chat interactions, as well as integrations with external services like MongoDB, OpenAI, Pinecone, and Neo4j.
+This directory contains the **server** side of the **Lumina** project – a robust backend built with **Node.js** and **Express** using **TypeScript**. The backend provides all the necessary API endpoints for user authentication, conversation management, and AI chat interactions, as well as integrations with external services like MongoDB, Google Gemini, Pinecone, and Neo4j.
 
 ---
 
@@ -36,7 +36,7 @@ The Lumina backend is designed to handle:
 - **Secure API:** Implements robust JWT authentication and authorization mechanisms.
 - **Conversation Handling:** Supports creating, retrieving, updating, and deleting conversations.
 - **AI Chat Service:** Facilitates dynamic interactions with the AI, leveraging advanced language models.
-- **Hybrid RAG Pipeline:** Combines Pinecone vector similarity search with Neo4j graph traversal for comprehensive knowledge retrieval. Both retrieval paths run in parallel and their results are merged to produce grounded, citation-backed responses.
+- **Hybrid RAG Pipeline:** Combines Pinecone vector similarity search with Neo4j graph traversal for comprehensive knowledge retrieval. Both retrieval paths run in parallel via `Promise.allSettled`, so one failing path never blocks the other. Results are merged to produce grounded, citation-backed responses, and static resume fallback context can be used when live retrieval backends fail.
 - **Knowledge Graph:** Automatic entity extraction and relationship mapping stored in Neo4j AuraDB. Entities and relationships are extracted from ingested documents using Gemini AI and persisted as a queryable graph.
 - **External Integrations:** Seamlessly integrates with MongoDB, Pinecone, Neo4j, and other external services.
 - **Email & Password Management:** Endpoints for email verification and password reset functionality.
@@ -115,7 +115,7 @@ For additional API details, please refer to the OpenAPI specification file (`ope
    NEO4J_DATABASE=your_database
    ```
 
-   > **Note:** Neo4j is optional. When the Neo4j environment variables are not set or the database is unreachable, the system gracefully degrades to vector-only retrieval via Pinecone.
+   > **Note:** Neo4j is optional. When the Neo4j environment variables are not set or the database is unreachable, the system gracefully degrades to vector-only retrieval via Pinecone. If live retrieval backends fail, static resume fallback context is loaded from `server/knowledge/manifest.json` and referenced files.
 
 4. **Run the server in development mode:**
 
@@ -175,7 +175,7 @@ The graph commands manage the Neo4j knowledge graph that powers the graph-based 
 | `npm run knowledge:graph:status` | Display Neo4j connection status, node/edge counts, and schema info. |
 | `npm run knowledge:graph:rebuild` | Re-extract entities and relationships from all ingested sources and rebuild the graph from scratch. |
 
-When new sources are upserted via `knowledge:upsert` or `knowledge:sync`, entities and relationships are automatically extracted and stored in Neo4j alongside the Pinecone vector embeddings. Use `graph:rebuild` if you need to regenerate the graph after changes to the extraction logic or to recover from a corrupted graph state.
+When new sources are upserted via `knowledge:upsert` or `knowledge:sync`, entities and relationships are automatically extracted and stored in Neo4j alongside the Pinecone vector embeddings. Use `graph:rebuild` if you need to regenerate the graph after changes to the extraction logic or to recover from a corrupted graph state. The same manifest/file workflow also powers static resume fallback retrieval, so fallback data can be inserted, updated, or removed without changing runtime code.
 
 ---
 
@@ -207,7 +207,8 @@ server/
     │   ├── geminiService.ts  # AI service with hybrid vector+graph RAG
     │   ├── knowledgeBase.ts  # Chunking, embeddings, vector+graph ingestion
     │   ├── geminiEmbeddings.ts # Embedding generation
-    │   └── pineconeClient.ts # Pinecone vector DB client
+    │   ├── pineconeClient.ts # Pinecone vector DB client
+    │   └── staticResumeFallback.ts # File-backed fallback retrieval context
     ├── utils/                # Utility scripts (e.g., ephemeralConversations)
     │   └── ephemeralConversations.ts
     └── middleware/           # Express middleware (e.g., authentication)

--- a/server/src/services/geminiService.ts
+++ b/server/src/services/geminiService.ts
@@ -13,6 +13,7 @@ import {
 } from "./knowledgeBase";
 import { isNeo4jConfigured } from "./neo4jClient";
 import { retrieveGraphChunks } from "./graphKnowledge";
+import { retrieveStaticResumeFallbackSources } from "./staticResumeFallback";
 
 dotenv.config();
 
@@ -42,6 +43,17 @@ const isListQuery = (message: string): boolean =>
 
 const getEffectiveTopK = (message: string): number =>
   isListQuery(message) ? RAG_LIST_TOP_K : RAG_TOP_K;
+
+type HybridRetrievalResult = {
+  sources: SourceCitation[];
+  usedStaticFallback: boolean;
+};
+
+const toErrorMessage = (error: unknown): string => {
+  if (error instanceof Error) return error.message;
+  if (typeof error === "string") return error;
+  return String(error);
+};
 
 const mergeRetrievalResults = (
   vectorResults: SourceCitation[],
@@ -111,29 +123,62 @@ const expandListResults = async (
 const retrieveHybridSources = async (
   message: string,
   topK: number,
-): Promise<SourceCitation[]> => {
-  let results: SourceCitation[];
+): Promise<HybridRetrievalResult> => {
+  let results: SourceCitation[] = [];
+  let shouldUseStaticFallback = false;
 
   if (isNeo4jConfigured()) {
     const [vectorResult, graphResult] = await Promise.allSettled([
       retrieveKnowledgeChunks(message, topK + 5),
       retrieveGraphChunks(message, topK + 5),
     ]);
+
+    if (vectorResult.status === "rejected") {
+      console.warn(
+        `Vector retrieval failed: ${toErrorMessage(vectorResult.reason)}`,
+      );
+    }
+    if (graphResult.status === "rejected") {
+      console.warn(
+        `Graph retrieval failed: ${toErrorMessage(graphResult.reason)}`,
+      );
+    }
+
     const vectorSources =
       vectorResult.status === "fulfilled" ? vectorResult.value : [];
     const graphSources =
       graphResult.status === "fulfilled" ? graphResult.value : [];
     results = mergeRetrievalResults(vectorSources, graphSources, topK);
+
+    shouldUseStaticFallback =
+      vectorResult.status === "rejected" && graphSources.length === 0;
   } else {
-    results = await retrieveKnowledgeChunks(message, topK);
+    try {
+      results = await retrieveKnowledgeChunks(message, topK);
+    } catch (error) {
+      console.warn(
+        `Vector retrieval failed while graph retrieval is unavailable: ${toErrorMessage(error)}`,
+      );
+      shouldUseStaticFallback = true;
+    }
   }
 
   // For list queries, expand to fetch all chunks from the dominant source
-  if (isListQuery(message)) {
+  if (results.length > 0 && isListQuery(message)) {
     results = await expandListResults(results);
   }
 
-  return results;
+  if (shouldUseStaticFallback) {
+    const fallbackSources = await retrieveStaticResumeFallbackSources(
+      message,
+      topK,
+    );
+    if (fallbackSources.length > 0) {
+      return { sources: fallbackSources, usedStaticFallback: true };
+    }
+  }
+
+  return { sources: results, usedStaticFallback: false };
 };
 
 const IDENTITY_SYSTEM_INSTRUCTION =
@@ -440,10 +485,15 @@ export const chatWithAI = async (
     throw new Error("Missing GOOGLE_AI_API_KEY in environment variables");
   }
 
-  const sources = await retrieveHybridSources(
+  const { sources, usedStaticFallback } = await retrieveHybridSources(
     message,
     getEffectiveTopK(message),
   );
+  if (usedStaticFallback) {
+    console.warn(
+      "Using static resume fallback after retrieval backend failure.",
+    );
+  }
   if (sources.length === 0) {
     return getNoSourcesResponse();
   }
@@ -495,10 +545,15 @@ export const streamChatWithAI = async (
     throw new Error("Missing GOOGLE_AI_API_KEY in environment variables");
   }
 
-  const sources = await retrieveHybridSources(
+  const { sources, usedStaticFallback } = await retrieveHybridSources(
     message,
     getEffectiveTopK(message),
   );
+  if (usedStaticFallback) {
+    console.warn(
+      "Using static resume fallback after retrieval backend failure.",
+    );
+  }
   if (sources.length === 0) {
     const fallback = getNoSourcesResponse();
     onChunk(fallback.text);

--- a/server/src/services/staticResumeFallback.ts
+++ b/server/src/services/staticResumeFallback.ts
@@ -1,0 +1,242 @@
+import fs from "fs";
+import path from "path";
+import { chunkText, SourceCitation } from "./knowledgeBase";
+
+type StaticResumeManifestSource = {
+  externalId?: string;
+  title?: string;
+  sourceType?: string;
+  sourceUrl?: string;
+  file?: string;
+  content?: string;
+};
+
+type StaticResumeManifest = {
+  sources?: StaticResumeManifestSource[];
+};
+
+type RankedStaticChunk = SourceCitation & {
+  order: number;
+  searchText: string;
+  rank: number;
+};
+
+const SERVER_ROOT = path.resolve(__dirname, "../..");
+const STATIC_RESUME_MANIFEST_PATH = path.join(
+  SERVER_ROOT,
+  "knowledge",
+  "manifest.json",
+);
+const FALLBACK_SOURCE_PREFIX = "static-resume";
+const FALLBACK_CHUNK_OPTIONS = {
+  maxChars: 700,
+  minChars: 180,
+  overlapChars: 80,
+};
+const MIN_QUERY_TERM_LENGTH = 3;
+const DEFAULT_FALLBACK_TOP_K = 10;
+
+const FALLBACK_STOPWORDS = new Set([
+  "the",
+  "and",
+  "for",
+  "with",
+  "about",
+  "what",
+  "which",
+  "that",
+  "this",
+  "from",
+  "have",
+  "has",
+  "had",
+  "are",
+  "were",
+  "was",
+  "who",
+  "how",
+  "why",
+  "when",
+  "where",
+  "your",
+  "you",
+  "his",
+  "her",
+  "their",
+  "them",
+  "they",
+  "recent",
+  "recently",
+  "latest",
+  "new",
+]);
+
+const toErrorMessage = (error: unknown): string => {
+  if (error instanceof Error) return error.message;
+  if (typeof error === "string") return error;
+  return String(error);
+};
+
+const extractQueryTerms = (query: string): string[] => {
+  const tokens = query
+    .toLowerCase()
+    .split(/[^a-z0-9]+/g)
+    .filter(Boolean)
+    .filter(
+      (token) =>
+        token.length >= MIN_QUERY_TERM_LENGTH && !FALLBACK_STOPWORDS.has(token),
+    );
+  return Array.from(new Set(tokens));
+};
+
+const scoreChunk = (terms: string[], text: string): number => {
+  if (terms.length === 0) return 0;
+  const normalized = text.toLowerCase();
+  let hits = 0;
+  for (const term of terms) {
+    if (normalized.includes(term)) {
+      hits += 1;
+    }
+  }
+  return hits / terms.length;
+};
+
+const readStaticResumeManifestSources = async (): Promise<
+  StaticResumeManifestSource[]
+> => {
+  const raw = await fs.promises.readFile(STATIC_RESUME_MANIFEST_PATH, "utf8");
+  const parsed = JSON.parse(raw) as StaticResumeManifest;
+  if (!Array.isArray(parsed.sources)) {
+    throw new Error("Static resume manifest must contain a sources array.");
+  }
+  return parsed.sources;
+};
+
+const readSourceContent = async (
+  source: StaticResumeManifestSource,
+): Promise<string> => {
+  const inlineContent =
+    typeof source.content === "string" ? source.content.trim() : "";
+  if (inlineContent) {
+    return inlineContent;
+  }
+
+  const sourceFile = typeof source.file === "string" ? source.file.trim() : "";
+  if (!sourceFile) {
+    throw new Error("Static resume source is missing both content and file.");
+  }
+
+  const resolvedPath = path.resolve(SERVER_ROOT, sourceFile);
+  const fileContent = await fs.promises.readFile(resolvedPath, "utf8");
+  return fileContent.trim();
+};
+
+const buildFallbackChunks = async (): Promise<RankedStaticChunk[]> => {
+  const manifestSources = await readStaticResumeManifestSources();
+  const chunks: RankedStaticChunk[] = [];
+  let order = 0;
+
+  for (
+    let sourceIndex = 0;
+    sourceIndex < manifestSources.length;
+    sourceIndex++
+  ) {
+    const source = manifestSources[sourceIndex];
+    const title =
+      typeof source.title === "string" ? source.title.trim() : "Resume Source";
+    const externalId =
+      typeof source.externalId === "string" && source.externalId.trim()
+        ? source.externalId.trim()
+        : `source-${sourceIndex + 1}`;
+    const sourceType =
+      typeof source.sourceType === "string" && source.sourceType.trim()
+        ? source.sourceType.trim()
+        : "resume";
+
+    let content = "";
+    try {
+      content = await readSourceContent(source);
+    } catch (error) {
+      console.warn(
+        `Static resume fallback skipped "${title}": ${toErrorMessage(error)}`,
+      );
+      continue;
+    }
+
+    const parsedChunks = chunkText(content, FALLBACK_CHUNK_OPTIONS);
+    if (parsedChunks.length === 0) {
+      continue;
+    }
+
+    const staticSourceId = `${FALLBACK_SOURCE_PREFIX}::${externalId}`;
+    const sourceUrl =
+      typeof source.sourceUrl === "string" && source.sourceUrl.trim()
+        ? source.sourceUrl.trim()
+        : undefined;
+
+    for (let chunkIndex = 0; chunkIndex < parsedChunks.length; chunkIndex++) {
+      const snippet = parsedChunks[chunkIndex];
+      chunks.push({
+        id: `${staticSourceId}::${chunkIndex}`,
+        sourceId: staticSourceId,
+        title,
+        url: sourceUrl,
+        snippet,
+        sourceType,
+        chunkIndex,
+        score: 0,
+        order,
+        rank: 0,
+        searchText: `${title}\n${sourceType}\n${snippet}`,
+      });
+      order += 1;
+    }
+  }
+
+  return chunks;
+};
+
+/**
+ * Reads local resume knowledge files (manifest + text sources) as a no-network fallback.
+ * This is intentionally file-backed so source entries can be inserted/updated/deleted
+ * by editing the manifest and knowledge files without changing runtime code.
+ */
+export const retrieveStaticResumeFallbackSources = async (
+  query: string,
+  topK: number = DEFAULT_FALLBACK_TOP_K,
+): Promise<SourceCitation[]> => {
+  const fallbackTopK = Math.max(1, topK);
+
+  let chunks: RankedStaticChunk[];
+  try {
+    chunks = await buildFallbackChunks();
+  } catch (error) {
+    console.warn(
+      `Static resume fallback retrieval failed: ${toErrorMessage(error)}`,
+    );
+    return [];
+  }
+
+  if (chunks.length === 0) {
+    console.warn("Static resume fallback has no available chunks.");
+    return [];
+  }
+
+  const terms = extractQueryTerms(query);
+  const ranked = chunks
+    .map((chunk) => ({
+      ...chunk,
+      rank: scoreChunk(terms, chunk.searchText),
+    }))
+    .sort((a, b) => {
+      if (b.rank === a.rank) return a.order - b.order;
+      return b.rank - a.rank;
+    })
+    .slice(0, fallbackTopK)
+    .map(({ order, rank, searchText, ...citation }) => ({
+      ...citation,
+      score: rank,
+    }));
+
+  return ranked;
+};


### PR DESCRIPTION
This pull request updates the documentation across `ARCHITECTURE.md`, `README.md`, and `RAG.md` to clarify and expand on the system's graceful degradation and fallback mechanisms in the Retrieval-Augmented Generation (RAG) pipeline. The main focus is on describing how the system now uses a file-backed static resume fallback (from `server/knowledge/manifest.json` and local files) when both live retrieval backends (Pinecone and Neo4j) fail, ensuring responses remain grounded even during outages. The documentation also highlights the isolation of retrieval paths, the updated fallback logic, and the ease of maintaining fallback knowledge.

**Major documentation updates:**

**Graceful degradation and fallback enhancements:**
- Expanded the definition of graceful degradation to specify that, in addition to vector-only mode when Neo4j is unavailable, the system uses a static resume fallback context from local files if both live retrieval backends fail. [[1]](diffhunk://#diff-8f6366fd8e7a5fa30f7f05879999195b7cf5fa1e3d157822eb37f0e91d226cfdL64-R64) [[2]](diffhunk://#diff-8f6366fd8e7a5fa30f7f05879999195b7cf5fa1e3d157822eb37f0e91d226cfdL608-R608) [[3]](diffhunk://#diff-8f6366fd8e7a5fa30f7f05879999195b7cf5fa1e3d157822eb37f0e91d226cfdL661-R661) [[4]](diffhunk://#diff-8f6366fd8e7a5fa30f7f05879999195b7cf5fa1e3d157822eb37f0e91d226cfdR1180-R1181) [[5]](diffhunk://#diff-8f6366fd8e7a5fa30f7f05879999195b7cf5fa1e3d157822eb37f0e91d226cfdL1538-R1540) [[6]](diffhunk://#diff-8f6366fd8e7a5fa30f7f05879999195b7cf5fa1e3d157822eb37f0e91d226cfdL1556-R1561) [[7]](diffhunk://#diff-8f6366fd8e7a5fa30f7f05879999195b7cf5fa1e3d157822eb37f0e91d226cfdL1575-R1587) [[8]](diffhunk://#diff-8f6366fd8e7a5fa30f7f05879999195b7cf5fa1e3d157822eb37f0e91d226cfdL2262-R2268) [[9]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L162-R162) [[10]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L226-R226)

- Updated diagrams and flowcharts in both `ARCHITECTURE.md` and `RAG.md` to illustrate the new fallback logic, showing that static resume fallback is loaded if both retrieval paths fail, and only returns empty citations if no fallback sources are available. [[1]](diffhunk://#diff-8f6366fd8e7a5fa30f7f05879999195b7cf5fa1e3d157822eb37f0e91d226cfdL1556-R1561) [[2]](diffhunk://#diff-6e69fe4e8e676866ef094c75f328ad688be7486e42b146de36661af4a9102c32L1025-R1031)

**RAG pipeline and retrieval path isolation:**
- Clarified that retrieval from Pinecone and Neo4j occurs in parallel via `Promise.allSettled`, ensuring that a failure in one path does not block the other, and that fallback mechanisms are in place for total backend failure. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L108-R108) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L226-R226) [[3]](diffhunk://#diff-93e4a5263a598aad80002d4a45f54108d127c70824825011385e95987b233f8dL39-R39)

**Knowledge management and fallback maintainability:**
- Explained that the same manifest/file workflow used for knowledge ingestion also powers the static resume fallback, making it easy to update fallback data without code changes. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L447-R447) [[2]](diffhunk://#diff-93e4a5263a598aad80002d4a45f54108d127c70824825011385e95987b233f8dL178-R178)

**File and service references:**
- Updated backend and project file trees in documentation to include the new `staticResumeFallback.ts` module, which implements the file-backed fallback logic. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1006-R1007) [[2]](diffhunk://#diff-93e4a5263a598aad80002d4a45f54108d127c70824825011385e95987b233f8dL210-R211)

**Other minor improvements:**
- Updated references to Google Gemini as the primary AI model in the backend.

These changes make the system's resilience and knowledge fallback mechanisms clearer to both users and developers, and highlight the maintainability of fallback knowledge through existing workflows.