### PR TITLE
feat(passkeys): improve UI for passkey registration button and layout

### DIFF
--- a/client/src/pages/Passkeys.tsx
+++ b/client/src/pages/Passkeys.tsx
@@ -170,7 +170,7 @@ const Passkeys: React.FC = () => {
           </Alert>
         )}
 
-        <Box display="flex" gap={1} alignItems="flex-start" mb={2}>
+        <Box display="flex" gap={1} alignItems="center" mb={2}>
           <TextField
             label="Nickname (optional)"
             placeholder="e.g. iPhone, Work laptop"
@@ -182,16 +182,23 @@ const Passkeys: React.FC = () => {
           />
           <Button
             variant="contained"
+            size="small"
             startIcon={
               registering ? (
-                <CircularProgress size={18} color="inherit" />
+                <CircularProgress size={16} color="inherit" />
               ) : (
-                <FingerprintIcon />
+                <FingerprintIcon fontSize="small" />
               )
             }
             onClick={handleRegister}
             disabled={!supported || registering}
-            sx={{ whiteSpace: "nowrap" }}
+            sx={{
+              whiteSpace: "nowrap",
+              textTransform: "none",
+              flexShrink: 0,
+              px: 2,
+              height: 40,
+            }}
           >
             Add passkey
           </Button>


### PR DESCRIPTION
This pull request makes minor UI improvements to the passkey registration form in `Passkeys.tsx` to enhance visual alignment and button appearance.

- UI alignment and appearance:
  * Changed the alignment of the nickname input and button from `flex-start` to `center` for better vertical alignment.
  * Updated the "Add passkey" button to use a smaller size, adjusted icon sizes, and added custom styles for padding, height, and text transformation to improve consistency and appearance.