### PR TITLE
Update README with passkey sign-in and Toast notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,8 @@ Alternatively, the backup app is deployed live on Netlify at: [https://lumina-ai
 
 - **AI Chatbot:** Ask questions about David Nguyen and general topics; receive responses from an AI.
 - **User Authentication:** Sign up, log in, and log out using JWT authentication.
-- **Passkey (WebAuthn) Sign-in:** Passwordless login with Touch ID, Face ID, Windows Hello, or a phone via QR. Supports discoverable (usernameless) credentials and per-user passkey management at `/passkeys`. Email + password remains as a fallback.
+- **Passkey (WebAuthn) Sign-in:** Passwordless login with Touch ID, Face ID, Windows Hello, or a phone via QR. Supports discoverable (usernameless) credentials, an optional post-signup enrollment dialog, and per-user passkey management at `/passkeys` (list/add/nickname/revoke). Backed by `@simplewebauthn/server` v9 with a TTL-indexed `challenges` collection consumed exactly once. Email + password remains as a fallback.
+- **Toast Notifications:** Global `ToastProvider` surfaces auth, passkey, and API errors in non-blocking snackbars instead of `alert()` dialogs.
 - **Conversation History:** Save, retrieve, rename, and search past conversations (only for authenticated users).
 - **Auto-Generated Titles:** AI automatically generates concise, descriptive titles for new conversations based on the first message.
 - **Grounded Knowledge Base:** RAG (Retrieval-Augmented Generation) with Pinecone vector search and Neo4j graph traversal, plus inline citations; knowledge is managed via CLI (REPL or one-off commands) with manifest-based batch sync for easy knowledge management.

--- a/client/README.md
+++ b/client/README.md
@@ -41,6 +41,8 @@ The frontend seamlessly integrates with the backend to provide functionalities s
 
 - **AI Chat Interface:** Interact with an intelligent assistant that answers questions about David Nguyen and various topics.
 - **User Authentication:** Sign up, log in, and manage your account with JWT-based authentication.
+- **Passkey (WebAuthn) Sign-in:** Passwordless login with Touch ID, Face ID, Windows Hello, or a phone via QR. Supports discoverable (usernameless) credentials, an optional post-signup enrollment prompt, and a `/passkeys` management page for adding, naming, and revoking credentials. Email + password remains as a fallback.
+- **Toast Notifications:** Global `ToastProvider` surfaces success and error messages from auth/passkey flows instead of relying on `alert()`.
 - **Conversation History:** Save, retrieve, rename, and search your past interactions (available for authenticated users).
 - **Auto-Generated Titles:** AI automatically generates concise titles for conversations based on the first message.
 - **Theme Toggle:** Switch between dark and light modes, with your preference stored locally.
@@ -55,6 +57,7 @@ The frontend seamlessly integrates with the backend to provide functionalities s
 - **Material‑UI (MUI)** – for modern, responsive UI components
 - **React Router** – for seamless navigation between pages
 - **Axios** – for API communication with the backend
+- **@simplewebauthn/browser** – browser-side WebAuthn helpers (`startRegistration`, `startAuthentication`) for passkey flows
 - **React Markdown** – for rendering AI-generated markdown content
 
 ---
@@ -65,7 +68,8 @@ The client application features several distinct pages and components:
 
 - **Landing Page:** Showcases the app’s features with animations and call-to-action buttons.
 - **Homepage:** The central hub for chatting with the AI, featuring a collapsible sidebar for conversation history.
-- **Authentication Pages:** Includes login, signup, and password reset pages.
+- **Authentication Pages:** Includes login, signup, and password reset pages. The login page exposes a "Sign in with passkey" action when WebAuthn is available; signup offers a one-time enrollment dialog after account creation.
+- **Passkeys Page (`/passkeys`):** Authenticated route for adding, naming, and revoking passkeys. Reachable via the fingerprint icon in the navbar.
 - **Theme Toggle:** Easily switch between dark and light modes using the navigation bar.
 - **Responsive Design:** Ensures a consistent experience across all devices.
 

--- a/server/README.md
+++ b/server/README.md
@@ -53,6 +53,7 @@ The Lumina backend is designed to handle:
 - **MongoDB** (with Mongoose) – Data storage and object modeling.
 - **JWT (JSON Web Tokens)** – Secure authentication mechanism.
 - **Neo4j** (with neo4j-driver) – Graph database for entity-relationship knowledge retrieval.
+- **@simplewebauthn/server** – WebAuthn/FIDO2 server library powering passkey registration and authentication.
 - **Additional Libraries:** bcrypt, cors, dotenv, multer, nodemailer, openai, uuid, etc.
 - **Development Tools:** nodemon and ts-node for a smooth development experience.
 
@@ -65,7 +66,19 @@ The Lumina backend is designed to handle:
 - **POST /api/auth/signup:** Register a new user.
 - **POST /api/auth/login:** Authenticate a user and return a JWT.
 - **GET /api/auth/verify-email?email=example@example.com:** Verify if an email exists.
-- **POST /api/auth/reset-password:** Reset a user’s password.
+- **POST /api/auth/reset-password:** Reset a user's password.
+- **GET /api/auth/validate-token:** Validate the current JWT token.
+
+#### Passkeys (WebAuthn)
+
+- **POST /api/auth/passkey/register/options:** Begin passkey registration for the authenticated user. Returns WebAuthn options + an opaque `challengeId`.
+- **POST /api/auth/passkey/register/verify:** Complete passkey registration. Persists the new credential on the user document.
+- **POST /api/auth/passkey/login/options:** Begin passkey sign-in. Body may include `email` to scope the prompt; omit it for discoverable (usernameless) login.
+- **POST /api/auth/passkey/login/verify:** Complete passkey sign-in and return a JWT (same shape as `/login`).
+- **GET /api/auth/passkey:** List the authenticated user's registered passkeys.
+- **DELETE /api/auth/passkey/:credentialId:** Remove a registered passkey.
+
+Challenges are stored in a `challenges` collection with a TTL index (5-minute expiry) and consumed exactly once. Email + password remains the fallback if a user loses every passkey.
 
 ### Conversations
 
@@ -116,6 +129,14 @@ For additional API details, please refer to the OpenAPI specification file (`ope
    NEO4J_USERNAME=your_username
    NEO4J_PASSWORD=your_password
    NEO4J_DATABASE=your_database
+
+   # Passkeys (WebAuthn). RP_ID is the apex domain — no scheme, no port.
+   # EXPECTED_ORIGIN is a comma-separated list of front-end origins allowed to
+   # register or sign in. Credentials are domain-bound; changing RP_ID after
+   # users enroll invalidates all previously-registered passkeys.
+   WEBAUTHN_RP_ID=localhost
+   WEBAUTHN_RP_NAME=Lumina AI
+   WEBAUTHN_EXPECTED_ORIGIN=http://localhost:3000
    ```
 
    > **Note:** Neo4j is optional. When the Neo4j environment variables are not set or the database is unreachable, the system gracefully degrades to vector-only retrieval via Pinecone. If live retrieval backends fail, static resume fallback context is loaded from `server/knowledge/manifest.json` and referenced files.


### PR DESCRIPTION
This pull request updates the documentation for both the frontend and backend to reflect the new passkey (WebAuthn) authentication features, as well as the introduction of global toast notifications for error and success messages. It also details new API endpoints and environment variables related to passkey flows, and clarifies the user experience for authentication and passkey management.

**Authentication and Passkey Features:**

* Expanded passkey (WebAuthn) support is now documented, including discoverable credentials, post-signup enrollment prompts, and a `/passkeys` management page for adding, naming, and revoking credentials. The backend is powered by `@simplewebauthn/server` with a TTL-indexed `challenges` collection for security. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L107-R108) [[2]](diffhunk://#diff-c4577d0b3a9c55c4e75639bb45f3dd659e83bc31b7a30943fda6ef84f7cef47aR44-R45) [[3]](diffhunk://#diff-c4577d0b3a9c55c4e75639bb45f3dd659e83bc31b7a30943fda6ef84f7cef47aL68-R72) [[4]](diffhunk://#diff-93e4a5263a598aad80002d4a45f54108d127c70824825011385e95987b233f8dL68-R81) [[5]](diffhunk://#diff-93e4a5263a598aad80002d4a45f54108d127c70824825011385e95987b233f8dR56)

* The authentication flow documentation now specifies that the login page exposes a "Sign in with passkey" option when WebAuthn is available, and signup offers a one-time enrollment dialog after account creation.

**User Experience Improvements:**

* Global `ToastProvider` is introduced in the frontend to display authentication, passkey, and API errors or success messages in non-blocking snackbars instead of `alert()` dialogs. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L107-R108) [[2]](diffhunk://#diff-c4577d0b3a9c55c4e75639bb45f3dd659e83bc31b7a30943fda6ef84f7cef47aR44-R45)

**API and Backend Enhancements:**

* New backend API endpoints for passkey registration, authentication, and management are documented, including endpoints for starting and verifying registration and login, listing, and deleting passkeys. The fallback to email and password is also clarified.

* The backend README now lists `@simplewebauthn/server` as a dependency and explains the use of a TTL-indexed `challenges` collection for secure, one-time challenge consumption. [[1]](diffhunk://#diff-93e4a5263a598aad80002d4a45f54108d127c70824825011385e95987b233f8dR56) [[2]](diffhunk://#diff-93e4a5263a598aad80002d4a45f54108d127c70824825011385e95987b233f8dL68-R81)

**Configuration Updates:**

* New environment variables for WebAuthn (`WEBAUTHN_RP_ID`, `WEBAUTHN_RP_NAME`, `WEBAUTHN_EXPECTED_ORIGIN`) are documented, with guidance on their usage and security implications.

**Frontend Library Additions:**

* The frontend now lists `@simplewebauthn/browser` as a dependency for handling browser-side WebAuthn flows.