### PR TITLE
fix(landing): animate decorative hero ring on load

### DIFF
--- a/client/src/pages/LandingPage.tsx
+++ b/client/src/pages/LandingPage.tsx
@@ -210,6 +210,17 @@ const LandingPage: React.FC = () => {
     },
   };
 
+  // Decorative outline ring behind the hero cards: fade + scale from center so
+  // it eases in with the stagger instead of sitting there on first paint.
+  const heroRingVariants = {
+    hidden: { opacity: 0, scale: 0.85 },
+    visible: {
+      opacity: 1,
+      scale: 1,
+      transition: { duration: 0.9, ease: "easeOut" },
+    },
+  };
+
   const heroBadges = [
     "About David Nguyen",
     "Resume-ready answers",
@@ -707,6 +718,8 @@ const LandingPage: React.FC = () => {
               }}
             >
               <Box
+                component={motion.div}
+                variants={heroRingVariants}
                 sx={{
                   position: { xs: "absolute", md: "absolute" },
                   inset: { xs: "auto", md: "12% 10%" },


### PR DESCRIPTION
## Summary
Follow-up to #58. The decorative outline ring behind the hero cards had no entrance and sat fully visible on first paint. Add a gentle fade + scale-from-center variant (`heroRingVariants`, 0.85 → 1, 0.9s easeOut) so it eases in as part of the hero stagger.

## Validation
- `npm run build` in `client/` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)